### PR TITLE
package_manager: remove --skip-alias in which command

### DIFF
--- a/rrmngmnt/package_manager.py
+++ b/rrmngmnt/package_manager.py
@@ -17,7 +17,7 @@ class PackageManager(Service):
             raise NotImplementedError("Name of binary file is not available.")
         rc, _, _ = h.executor().run_cmd(
             [
-                'which', '--skip-alias', cls.binary,
+                'which', cls.binary,
             ]
         )
         return not rc


### PR DESCRIPTION
Since debian system use different which,
it don't have --skip-alias option, and
it skip aliases by default. But we need
to work on most system, so removing.